### PR TITLE
鳥の当たり判定コライダーの修正とNet.csの設定変更

### DIFF
--- a/Pandator/Assets/NetGun/Net/Scripts/Net.cs
+++ b/Pandator/Assets/NetGun/Net/Scripts/Net.cs
@@ -47,7 +47,7 @@ public class Net : MonoBehaviour
         {
             isCollision = true;
             //Netの中に入れる
-            Player.GetComponent<SphereCollider>().isTrigger = true;
+            Player.GetComponent<BoxCollider>().isTrigger = true;
             //速度を0に
             GetComponent<Rigidbody>().linearVelocity = Vector3.zero;
             transform.position = Player.transform.position;

--- a/Pandator/Assets/Resources/Player/BirdPlayer.prefab
+++ b/Pandator/Assets/Resources/Player/BirdPlayer.prefab
@@ -554,6 +554,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 4549435062556395408, guid: ae6c99a9b9fae4ff887cf09947264e97, type: 3}
       insertIndex: -1
       addedObject: {fileID: 5164755693211121568}
+    - targetCorrespondingSourceObject: {fileID: 4549435062556395408, guid: ae6c99a9b9fae4ff887cf09947264e97, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8773034350506361957}
   m_SourcePrefab: {fileID: 100100000, guid: ae6c99a9b9fae4ff887cf09947264e97, type: 3}
 --- !u!4 &3621555379604008764 stripped
 Transform:
@@ -602,7 +605,7 @@ SphereCollider:
   m_LayerOverridePriority: 0
   m_IsTrigger: 1
   m_ProvidesContacts: 0
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 3
   m_Radius: 0.43800396
   m_Center: {x: -0.053215742, y: 0.4887637, z: 0.07171863}
@@ -618,6 +621,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 45b7416fc37c44b30b73190a94051c6b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!65 &8773034350506361957
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4109967603769013638}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 0.9677929, z: 0.86312085}
+  m_Center: {x: 0, y: 0.49389648, z: 0.028181225}
 --- !u!114 &5338401572920123032 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5493988184530889870, guid: ae6c99a9b9fae4ff887cf09947264e97, type: 3}

--- a/Pandator/Pandator_BurstDebugInformation_DoNotShip/tempburstlibs/arm64-v8a/lib_burst_generated.txt
+++ b/Pandator/Pandator_BurstDebugInformation_DoNotShip/tempburstlibs/arm64-v8a/lib_burst_generated.txt
@@ -1,4 +1,4 @@
-Library: /Users/taramanjimacbookpro/DuHang/Pandator/Temp/BurstOutput/tempburstlibs/arm64-v8a/lib_burst_generated
+Library: /Users/kumamac/DuHang/Pandator/Temp/BurstOutput/tempburstlibs/arm64-v8a/lib_burst_generated
 --platform=Android
 --backend=burst-llvm-16
 --target=ARMV8A_AARCH64
@@ -8,10 +8,10 @@ Library: /Users/taramanjimacbookpro/DuHang/Pandator/Temp/BurstOutput/tempburstli
 --float-precision=Standard
 --target-framework=NetFramework
 --generate-link-xml=Temp/burst.link.xml
---temp-folder=/Users/taramanjimacbookpro/DuHang/Pandator/Temp/Burst
+--temp-folder=/Users/kumamac/DuHang/Pandator/Temp/Burst
 --key-folder=/Applications/Unity/Hub/Editor/6000.0.36f1/PlaybackEngines/AndroidPlayer
---decode-folder=/Users/taramanjimacbookpro/DuHang/Pandator/Library/Burst
---output=/Users/taramanjimacbookpro/DuHang/Pandator/Temp/BurstOutput/tempburstlibs/arm64-v8a/lib_burst_generated
+--decode-folder=/Users/kumamac/DuHang/Pandator/Library/Burst
+--output=/Users/kumamac/DuHang/Pandator/Temp/BurstOutput/tempburstlibs/arm64-v8a/lib_burst_generated
 --pdb-search-paths=Temp/ManagedSymbols/
 
 --method=Unity.Burst.BurstCompiler+BurstCompilerHelper, Unity.Burst, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null::IsBurstEnabled()--8c2be93e18276203cbd918daa2748a10
@@ -104,10 +104,10 @@ Library: /Users/taramanjimacbookpro/DuHang/Pandator/Temp/BurstOutput/tempburstli
 --target-framework=NetFramework
 --float-mode=Fast
 --generate-link-xml=Temp/burst.link.xml
---temp-folder=/Users/taramanjimacbookpro/DuHang/Pandator/Temp/Burst
+--temp-folder=/Users/kumamac/DuHang/Pandator/Temp/Burst
 --key-folder=/Applications/Unity/Hub/Editor/6000.0.36f1/PlaybackEngines/AndroidPlayer
---decode-folder=/Users/taramanjimacbookpro/DuHang/Pandator/Library/Burst
---output=/Users/taramanjimacbookpro/DuHang/Pandator/Temp/BurstOutput/tempburstlibs/arm64-v8a/lib_burst_generated
+--decode-folder=/Users/kumamac/DuHang/Pandator/Library/Burst
+--output=/Users/kumamac/DuHang/Pandator/Temp/BurstOutput/tempburstlibs/arm64-v8a/lib_burst_generated
 --pdb-search-paths=Temp/ManagedSymbols/
 
 --method=Unity.Jobs.IJobForExtensions+ForJobStruct`1[[UnityEngine.Rendering.Universal.ZBinningJob, Unity.RenderPipelines.Universal.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]], UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null::Execute(UnityEngine.Rendering.Universal.ZBinningJob&, Unity.RenderPipelines.Universal.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null|System.IntPtr, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|System.IntPtr, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089|Unity.Jobs.LowLevel.Unsafe.JobRanges&, UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null|System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)--77fc393cb521ac129b1392d4eb94d29a


### PR DESCRIPTION
## 鳥の当たり判定コライダーの修正とNet.csの設定変更

## 概要
- 鳥についてる弾の衝突判定用のcolliderを変更
- Net.csの反応するcolliderをBoxに変えました

## 実装結果・プレビュー
- パンダで網を当てると、小動物が黒焦げになった