### PR TITLE
LOG-120 スコア計算方法変えました

### DIFF
--- a/Pandator/Assets/Manager/Scripts/ScoreManager.cs
+++ b/Pandator/Assets/Manager/Scripts/ScoreManager.cs
@@ -5,6 +5,9 @@ public class ScoreManager : MonoBehaviour
     private float score;
     private float aliveTime;
     private int interruptedCount;
+    [Header("スコア計算用")]
+    [SerializeField] private float scoreMultiplier; // スコアの倍率
+    [SerializeField] private float hitPoint; // 妨害のスコア
 
     private void Start()
     {
@@ -36,6 +39,10 @@ public class ScoreManager : MonoBehaviour
     // スコア計算 10ポイント/秒 + 5ポイント/中断 これは適当
     private void CalculateScore()
     {
-        score = aliveTime * 10 + interruptedCount * 5;
+        // 非線形スコア計算: aliveTimeの2乗を使用
+        score = Mathf.Pow(aliveTime, 2) / scoreMultiplier + interruptedCount * hitPoint;
+
+        // 小数点以下を切り捨て
+        score = Mathf.Floor(score);
     }
 }

--- a/Pandator/Assets/Resources/Player/BirdPlayer.prefab
+++ b/Pandator/Assets/Resources/Player/BirdPlayer.prefab
@@ -180,6 +180,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 626a1c262a6b64400862dee5fbfc93ab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  scoreMultiplier: 100
+  hitPoint: 50
 --- !u!114 &5823670346237709383
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Pandator/Assets/Resources/Player/MousePlayer.prefab
+++ b/Pandator/Assets/Resources/Player/MousePlayer.prefab
@@ -105,6 +105,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 626a1c262a6b64400862dee5fbfc93ab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  scoreMultiplier: 100
+  hitPoint: 50
 --- !u!114 &6314878593413762173
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Pandator/Assets/Resources/Player/RabbitPlayer.prefab
+++ b/Pandator/Assets/Resources/Player/RabbitPlayer.prefab
@@ -137,6 +137,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 626a1c262a6b64400862dee5fbfc93ab, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  scoreMultiplier: 100
+  hitPoint: 50
 --- !u!114 &9198865818353753367
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Pandator/Assets/Scenes/tutorial/tutorialScene.prefab
+++ b/Pandator/Assets/Scenes/tutorial/tutorialScene.prefab
@@ -83,7 +83,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8ecb01b3775f145e1a9acd85afe67adb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  nextScene: 0
+  nextScene: 1
   setChangeSceneLogoScript: {fileID: 1025172280617525646}
 --- !u!1 &6045353009627044728
 GameObject:
@@ -447,10 +447,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 346653f9a4b2f4ac2a19a4b705cbe2e6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  character: 3
+  character: 0
   roomPrefab: {fileID: 5991780742326204619}
   passthrough: {fileID: 6045353009627044728}
   planePrefab: {fileID: 8964321946455890345}
+  OVRSceneManager: {fileID: 841676588387879430}
 --- !u!1 &8964321946455890345
 GameObject:
   m_ObjectHideFlags: 0
@@ -480,7 +481,7 @@ Transform:
   m_GameObject: {fileID: 8964321946455890345}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.23194444, y: -0.18916816, z: -0.03821493}
+  m_LocalPosition: {x: -0.23194444, y: -0.049, z: -0.03821493}
   m_LocalScale: {x: 1.05, y: 1.05, z: 1.05}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -746,6 +747,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c813208e672e3074bbe118e1a9ee94fd, type: 3}
+--- !u!1 &841676588387879430 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 747806495401477014, guid: c813208e672e3074bbe118e1a9ee94fd, type: 3}
+  m_PrefabInstance: {fileID: 130184850173708688}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &841676588387879483 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 747806495401477035, guid: c813208e672e3074bbe118e1a9ee94fd, type: 3}


### PR DESCRIPTION
## issues
#スコアの計算方法決めました

## 概要
- 計算式としては「(生存時間^2) / 調整用数(今は100) + 妨害得点(今は50)✖️妨害した回数」にしてる
- 調整用数と妨害得点はSerializeFieldで変えられるようにしてます
- 自分の理想としては1000点前後に収まるように調整をしたい

## 注意点
- 正直配分はやってみないとわからん

## 実装結果・プレビュー