### PR TITLE
LOG-134 セレクトシーンのコントローラーでの選択を改善しました

### DIFF
--- a/Pandator/Assets/SelectScenes/Scripts/AnimalSelectManager.cs
+++ b/Pandator/Assets/SelectScenes/Scripts/AnimalSelectManager.cs
@@ -4,39 +4,89 @@ using UnityEngine.SceneManagement; // シーン遷移に必要
 public class AnimalSelectManager : MonoBehaviour
 {
     private bool isAnimalSelected = false; // 動物が選択されたかどうかのフラグ
-    [SerializeField] private bool isDebugFlag = true; // 動物選択UI
+    [SerializeField] private bool isDebugFlag = true; // デバッグ用フラグ
     [SerializeField] private SelectedAnimalUI selectedAnimalUI; // 動物選択UI
+
+    private int currentSelectionIndex = 0; // 現在選択されているキャラクターのインデックス
+    private Character.GameCharacters[] animals = new Character.GameCharacters[]
+    {
+        Character.GameCharacters.BIRD,
+        Character.GameCharacters.RABBIT,
+        Character.GameCharacters.MOUSE
+    };
+
+    private void Start()
+    {
+        // 初期状態のUIを更新
+        UpdateSelectionUI();
+    }
 
     // Update is called once per frame
     private void Update()
     {
-        // Aボタンが押された場合
-        if (OVRInput.Get(OVRInput.Button.One) || Input.GetKeyDown(KeyCode.R)) // Aボタン
+        // 左の中指ボタンで左に移動
+        if (OVRInput.GetDown(OVRInput.Button.PrimaryHandTrigger) || Input.GetKeyDown(KeyCode.LeftArrow))
         {
-            SelectAnimal(Character.GameCharacters.RABBIT);
-            selectedAnimalUI.RabbitedSelected();
+            MoveSelectionLeft();
         }
-        // Bボタンが押された場合
-        else if (OVRInput.Get(OVRInput.Button.Two) || Input.GetKeyDown(KeyCode.B)) // Bボタン
+        // 右の中指ボタンで右に移動
+        else if (OVRInput.GetDown(OVRInput.Button.SecondaryHandTrigger) || Input.GetKeyDown(KeyCode.RightArrow))
         {
-            SelectAnimal(Character.GameCharacters.BIRD);
-            selectedAnimalUI.BirdSelected();
+            MoveSelectionRight();
         }
-        // Xボタンが押された場合
-        else if (OVRInput.Get(OVRInput.Button.Three) || Input.GetKeyDown(KeyCode.M)) // Xボタン
+
+        // A,B,X,Yボタンで選択を確定
+        if ((OVRInput.Get(OVRInput.Button.PrimaryIndexTrigger) && OVRInput.Get(OVRInput.Button.SecondaryIndexTrigger)) || Input.GetKeyDown(KeyCode.Return))
         {
-            SelectAnimal(Character.GameCharacters.MOUSE);
-            selectedAnimalUI.MouseSelected();
-        }
-        // Yボタンが押された場合
-        else if (isDebugFlag && (OVRInput.Get(OVRInput.Button.Four) || Input.GetKeyDown(KeyCode.P))) // Yボタン
+            SelectAnimal(animals[currentSelectionIndex]);
+        }  else if ((OVRInput.Get(OVRInput.Button.One) && OVRInput.Get(OVRInput.Button.Two)) || Input.GetKeyDown(KeyCode.P)) // Yボタン
         {
             SelectAnimal(Character.GameCharacters.PANDA);
-            selectedAnimalUI.ResetAnimalUI();
         }
-        if (isAnimalSelected && (OVRInput.GetDown(OVRInput.Button.SecondaryIndexTrigger) || Input.GetKeyDown(KeyCode.O)))
+
+        // // チュートリアルシーンに遷移
+        // if (isAnimalSelected && (OVRInput.GetDown(OVRInput.Button.SecondaryIndexTrigger) || Input.GetKeyDown(KeyCode.O)))
+        // {
+        //     GoToTutorialScene();
+        // }
+    }
+
+    private void MoveSelectionLeft()
+    {
+        currentSelectionIndex--;
+        if (currentSelectionIndex < 0)
         {
-            GoToTutorialScene();
+            currentSelectionIndex = animals.Length - 1; // 一番右にループ
+        }
+        UpdateSelectionUI();
+        Debug.Log($"Current Selection: {animals[currentSelectionIndex]}");
+    }
+
+    private void MoveSelectionRight()
+    {
+        currentSelectionIndex++;
+        if (currentSelectionIndex >= animals.Length)
+        {
+            currentSelectionIndex = 0; // 一番左にループ
+        }
+        UpdateSelectionUI();
+        Debug.Log($"Current Selection: {animals[currentSelectionIndex]}");
+    }
+
+    private void UpdateSelectionUI()
+    {
+        // 現在の選択に応じてUIを更新
+        switch (animals[currentSelectionIndex])
+        {
+            case Character.GameCharacters.BIRD:
+                selectedAnimalUI.BirdSelected();
+                break;
+            case Character.GameCharacters.RABBIT:
+                selectedAnimalUI.RabbitedSelected();
+                break;
+            case Character.GameCharacters.MOUSE:
+                selectedAnimalUI.MouseSelected();
+                break;
         }
     }
 
@@ -44,8 +94,12 @@ public class AnimalSelectManager : MonoBehaviour
     {
         Character.SetSelectedAnimal(animal);
         isAnimalSelected = true;
-        Debug.Log(animal);
+        Debug.Log($"Selected Animal: {animal}");
+
+        // チュートリアルシーンに移行
+        GoToTutorialScene();
     }
+
     private void GoToTutorialScene()
     {
         // チュートリアルシーンに遷移する処理

--- a/Pandator/Assets/SelectScenes/Scripts/SelectedAnimalUI.cs
+++ b/Pandator/Assets/SelectScenes/Scripts/SelectedAnimalUI.cs
@@ -48,5 +48,4 @@ public class SelectedAnimalUI : MonoBehaviour
         mouseFrame.color = Color.yellow;
         mouseNameUI.color = Color.yellow;
     }
-
 }


### PR DESCRIPTION
## issues
#
- セレクトシーンの動物選択をわかりやすい方法に変えたよん

## 概要
- セレクトシーンで動物を選ぶときにボタン操作ではなく、中指のボタンのトリガー操作で決めるようにしました
- 初期はバードにハイライトがあります
- 左右コントローラーの中指トリガーを押すとハイライトが左右に動く
- 決定するときは両手の人差し指のトリガーを押す
- パンダだけ特別で、右コントローラーのA,B同時押しでパンダは決定

## 実装結果・プレビュー
- メタクエで確認したよ