### PR TITLE
camerarigのlayerを調整

### DIFF
--- a/Pandator/Assets/Resources/CameraRig/BirdCameraRig.prefab
+++ b/Pandator/Assets/Resources/CameraRig/BirdCameraRig.prefab
@@ -171,7 +171,6 @@ GameObject:
   - component: {fileID: 287829237816166381}
   - component: {fileID: 2416649789414078557}
   - component: {fileID: 224267548846101444}
-  - component: {fileID: 8739595244652945986}
   m_Layer: 0
   m_Name: BirdCameraRig
   m_TagString: Untagged
@@ -334,22 +333,6 @@ MonoBehaviour:
   - <Keyboard>/leftAlt
   - <Keyboard>/rightAlt
   - <Keyboard>/f2
---- !u!114 &8739595244652945986
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3528499836265461033}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5bf2edfb042f04fb98e985c935d63124, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  cam: {fileID: 6903496662110101615}
-  animalLayerMask:
-    serializedVersion: 2
-    m_Bits: 64
 --- !u!1 &3785578283397347163
 GameObject:
   m_ObjectHideFlags: 0
@@ -433,7 +416,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 55
+    m_Bits: 4294967295
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0

--- a/Pandator/Assets/Resources/CameraRig/MouseCameraRig.prefab
+++ b/Pandator/Assets/Resources/CameraRig/MouseCameraRig.prefab
@@ -447,7 +447,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 119
+    m_Bits: 4294967295
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0

--- a/Pandator/Assets/Resources/CameraRig/RabbitCameraRig.prefab
+++ b/Pandator/Assets/Resources/CameraRig/RabbitCameraRig.prefab
@@ -447,7 +447,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 247
+    m_Bits: 4294967295
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0

--- a/Pandator/Assets/Resources/TutorialCameraRig/TutorialCameraRig.prefab
+++ b/Pandator/Assets/Resources/TutorialCameraRig/TutorialCameraRig.prefab
@@ -305,7 +305,7 @@ Camera:
   m_Depth: 0
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 55
+    m_Bits: 503
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0


### PR DESCRIPTION
## 概要
CameraRigのcullingmaskを調整してパンダ以外は自身が見えないように調整しました

(動作確認はtutorialsceneでは確認しました)