### PR TITLE
LOG-162 デバッグモードでデバッグ表示出るように

### DIFF
--- a/Pandator/.gitignore
+++ b/Pandator/.gitignore
@@ -93,4 +93,5 @@ Pandator_MR_BurstDebugInformation_DoNotShip/
 .vsconfig.rej
 .vsconfig
 
+/[Aa]ssets/UI/Fonts/
 

--- a/Pandator/.gitignore
+++ b/Pandator/.gitignore
@@ -93,5 +93,5 @@ Pandator_MR_BurstDebugInformation_DoNotShip/
 .vsconfig.rej
 .vsconfig
 
-/[Aa]ssets/UI/Fonts/
+/[Aa]ssets/[Uu][Ii]/[Ff]onts/
 

--- a/Pandator/Assets/Manager/Scripts/InitializeManager.cs
+++ b/Pandator/Assets/Manager/Scripts/InitializeManager.cs
@@ -80,10 +80,10 @@ public class InitializeManager : MonoBehaviourPunCallbacks
             }
             
             //debugCanvasを表示
-            GameObject debugCanvasTransform = GameObject.FindWithTag("DebugCanvas");
+            Transform debugCanvasTransform = spatialAnchor.transform.Find("DebugCanvas");
             if (debugCanvasTransform != null)
             {
-                debugCanvasTransform.SetActive(true);
+                debugCanvasTransform.gameObject.SetActive(true);
             }
             else
             {
@@ -96,10 +96,10 @@ public class InitializeManager : MonoBehaviourPunCallbacks
             }
             else
             {
-                Debug.LogError("SpatialAnchorLoader componentis missing on the tagged object!");;
+                Debug.LogError("SpatialAnchorLoader componentis missing on the tagged object!");
             }
 
-            SetupDebugEnvironment();
+            //SetupDebugEnvironment();
             return;
         }
 

--- a/Pandator/Assets/Manager/Scripts/InitializeManager.cs
+++ b/Pandator/Assets/Manager/Scripts/InitializeManager.cs
@@ -78,7 +78,18 @@ public class InitializeManager : MonoBehaviourPunCallbacks
             {
                 Debug.LogWarning("room_complete object not found under SpatialAnchor.");
             }
-
+            
+            //debugCanvasを表示
+            GameObject debugCanvasTransform = GameObject.FindWithTag("DebugCanvas");
+            if (debugCanvasTransform != null)
+            {
+                debugCanvasTransform.SetActive(true);
+            }
+            else
+            {
+                Debug.Log("debugCanvas object not found.");
+            }
+            
             if (spatialAnchorLoader)
             {
                 SetupDebugEnvironment();
@@ -137,7 +148,7 @@ public class InitializeManager : MonoBehaviourPunCallbacks
         Instantiate(Resources.Load<GameObject>("CameraRig/debugCamera"));
         Transform canvasTransform = spatialAnchor.transform
             .GetComponentsInChildren<Transform>()
-            .FirstOrDefault(t => t.CompareTag("Canvas"));
+            .FirstOrDefault(t => t.CompareTag("DebugCanvas"));
 
         if (canvasTransform != null)
         {

--- a/Pandator/Assets/Resources/SpatialAnchor/prefab/spatialAnchor.prefab
+++ b/Pandator/Assets/Resources/SpatialAnchor/prefab/spatialAnchor.prefab
@@ -1011,8 +1011,8 @@ GameObject:
   - component: {fileID: 6890680543571994856}
   - component: {fileID: 8844792784044444829}
   m_Layer: 5
-  m_Name: Canvas
-  m_TagString: Canvas
+  m_Name: DebugCanvas
+  m_TagString: DebugCanvas
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Pandator/Assets/Resources/SpatialAnchor/prefab/spatialAnchor.prefab
+++ b/Pandator/Assets/Resources/SpatialAnchor/prefab/spatialAnchor.prefab
@@ -448,7 +448,7 @@ RectTransform:
   m_GameObject: {fileID: 2619168315556994609}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.3, y: 0.59, z: 1}
+  m_LocalScale: {x: 0.12, y: 0.3, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5824048889624634857}

--- a/Pandator/ProjectSettings/TagManager.asset
+++ b/Pandator/ProjectSettings/TagManager.asset
@@ -25,6 +25,7 @@ TagManager:
   - BGM
   - InterruptItem
   - Net
+  - DebugCanvas
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## issues
#

## 概要
- デバックモードでdebugCanvasが表示されない不具合を解消
- 表示のためにdebugCanvasタグを追加してます
- 基本falseで見えないようにしていて、debugモード時にsetActive(true)にするようにしてる
- あと、debugCameraが二つ出るようになってたからそれも直した

## 実装結果・プレビュー
- 実際にメタクエで確認した
- 他のシーンでは出ません