### PR TITLE
Fix/Reposition 位置リセットボタンの追加

### DIFF
--- a/Pandator/Assets/Bird/Scripts/BirdMoveController.cs
+++ b/Pandator/Assets/Bird/Scripts/BirdMoveController.cs
@@ -43,16 +43,13 @@ public class BirdMoveController : MonoBehaviour
     
     private float xAngle = 0f;
     private float yAngle = 0f;
-
-    // --- 追加 ---
+    
     private Transform spawnPoint; // スポーン地点のTransform
-    // --- 追加ここまで ---
 
     void Start()
     {
         CharacterController = GetComponent<CharacterController>();
-
-        // --- 追加 ---
+        
         // "playerSpawn"タグを持つゲームオブジェクトを検索して登録
         GameObject spawnObject = GameObject.FindWithTag("playerSpawn");
         if (spawnObject != null)
@@ -64,7 +61,6 @@ public class BirdMoveController : MonoBehaviour
             // 見つからなかった場合にエラーメッセージを表示
             Debug.LogError("Error: 'playerSpawn' tag not found in the scene.");
         }
-        // --- 追加ここまで ---
     }
 
 
@@ -72,11 +68,8 @@ public class BirdMoveController : MonoBehaviour
 
     {
         if (!isInitialized) return;
-
-        // --- 追加 ---
-        // リスポーン処理
-        // キーボードの'R'キーか、Meta Questの右コントローラーの'A'ボタンが押された瞬間をチェック
-        if (Input.GetKeyDown(KeyCode.R) || OVRInput.GetDown(OVRInput.Button.One, OVRInput.Controller.RTouch))
+        // キーボードの'R'キーか、Meta Questの左コントローラーの'X,Y'ボタンが押された瞬間をチェック
+        if (Input.GetKeyDown(KeyCode.R) || (OVRInput.Get(OVRInput.Button.Three) && OVRInput.Get(OVRInput.Button.Four)))
         {
             // spawnPointが設定されていれば、その位置に移動
             if (spawnPoint != null && CharacterController != null)
@@ -93,7 +86,6 @@ public class BirdMoveController : MonoBehaviour
                 return; // このフレームでは他の移動処理を行わない
             }
         }
-        // --- 追加ここまで ---
 
 
         if (Input.GetKeyDown(KeyCode.K))

--- a/Pandator/Assets/Bird/Scripts/BirdMoveController.cs
+++ b/Pandator/Assets/Bird/Scripts/BirdMoveController.cs
@@ -44,9 +44,27 @@ public class BirdMoveController : MonoBehaviour
     private float xAngle = 0f;
     private float yAngle = 0f;
 
+    // --- 追加 ---
+    private Transform spawnPoint; // スポーン地点のTransform
+    // --- 追加ここまで ---
+
     void Start()
     {
         CharacterController = GetComponent<CharacterController>();
+
+        // --- 追加 ---
+        // "playerSpawn"タグを持つゲームオブジェクトを検索して登録
+        GameObject spawnObject = GameObject.FindWithTag("playerSpawn");
+        if (spawnObject != null)
+        {
+            spawnPoint = spawnObject.transform;
+        }
+        else
+        {
+            // 見つからなかった場合にエラーメッセージを表示
+            Debug.LogError("Error: 'playerSpawn' tag not found in the scene.");
+        }
+        // --- 追加ここまで ---
     }
 
 
@@ -54,6 +72,29 @@ public class BirdMoveController : MonoBehaviour
 
     {
         if (!isInitialized) return;
+
+        // --- 追加 ---
+        // リスポーン処理
+        // キーボードの'R'キーか、Meta Questの右コントローラーの'A'ボタンが押された瞬間をチェック
+        if (Input.GetKeyDown(KeyCode.R) || OVRInput.GetDown(OVRInput.Button.One, OVRInput.Controller.RTouch))
+        {
+            // spawnPointが設定されていれば、その位置に移動
+            if (spawnPoint != null && CharacterController != null)
+            {
+                // CharacterControllerをテレポートさせるための推奨手順
+                CharacterController.enabled = false; // 一時的に無効化
+                transform.position = spawnPoint.position;
+                CharacterController.enabled = true;  // 再度有効化
+
+                // 飛行状態や速度などのステータスをリセット
+                isFlying = false;
+                verticalVelocity = 0f;
+                
+                return; // このフレームでは他の移動処理を行わない
+            }
+        }
+        // --- 追加ここまで ---
+
 
         if (Input.GetKeyDown(KeyCode.K))
         {
@@ -82,7 +123,6 @@ public class BirdMoveController : MonoBehaviour
             xAngle -= mouseY;
             xAngle = Mathf.Clamp(xAngle, -90f, 90f);
             yAngle += mouseX;
-            // yAngle = Mathf.Clamp(yAngle, -90f, 90f);
             CenterEyeAnchor.localRotation = Quaternion.Euler(xAngle, yAngle, 0);
         }
     }
@@ -116,20 +156,6 @@ public class BirdMoveController : MonoBehaviour
                 isFlying = false;
             }
         }
-
-        //以下内容用于脱离VR环境使用
-
-        //bool isAButtonPressed = OVRInput.Get(OVRInput.Button.One);
-        //if (isAButtonPressed)
-        //{
-        //    isFlying = true;
-        //    verticalVelocity = liftForce;
-        //}
-        //else
-        //{
-        //    isFlying = false;
-        //}
-
     }
     void HandleWalking()
     {
@@ -182,14 +208,6 @@ public class BirdMoveController : MonoBehaviour
 
     void HandleFlight()
     {
-        //// 刚刚按下 A
-        //bool isAButtonDown = OVRInput.GetDown(OVRInput.Button.One);
-
-        ////是否持续按住 A
-        //bool isAButtonPressed = OVRInput.Get(OVRInput.Button.One);
-        //这部分为后续添加的飞行控制或者技能代码提供接口，暂时不需要
-        //*this part is for the future flight control or skill code, not needed for now
-
         //根据是否按住飞行按钮来施加重力 //apply gravity based on the flight button // 飛行ボタンの押下状態に応じて重力を適用する
         if (!isFlying) return;
 

--- a/Pandator/Assets/Mouse/Scripts/MouseMove.cs
+++ b/Pandator/Assets/Mouse/Scripts/MouseMove.cs
@@ -26,9 +26,7 @@ public class MouseMove : MonoBehaviour
     private float xAngle = 0f;
     private float yAngle = 0f;
     
-    // --- 追加 ---
     private Transform spawnPoint; // スポーン地点のTransform
-    // --- 追加ここまで ---
     
 
     private void Start()
@@ -37,8 +35,7 @@ public class MouseMove : MonoBehaviour
         moveSpeed = normalSpeed; // 初期値を通常速度に設定
         InitializeManager = GameObject.FindWithTag("InitializeManager").GetComponent<InitializeManager>();
         floarValue = InitializeManager.GetLocalAnchorPosition().y;
-
-        // --- 追加 ---
+        
         // "playerSpawn"タグを持つゲームオブジェクトを検索して登録
         GameObject spawnObject = GameObject.FindWithTag("playerSpawn");
         if (spawnObject != null)
@@ -50,7 +47,6 @@ public class MouseMove : MonoBehaviour
             // 見つからなかった場合にエラーメッセージを表示
             Debug.LogError("Error: 'playerSpawn' tag not found in the scene.");
         }
-        // --- 追加ここまで ---
     }
 
     private void Update()
@@ -63,9 +59,8 @@ public class MouseMove : MonoBehaviour
         // IsMineで自分のキャラクターかどうかを判定
         if (GetComponent<PhotonView>().IsMine)
         {
-            // --- 追加 ---
-            // キーボードの'R'キーか、Meta Questの右コントローラーの'A'ボタンが押された瞬間をチェック
-            if (Input.GetKeyDown(KeyCode.R) || OVRInput.GetDown(OVRInput.Button.One, OVRInput.Controller.RTouch))
+            // キーボードの'R'キーか、Meta Questの左コントローラーの'X,Y'ボタンが押された瞬間をチェック
+            if (Input.GetKeyDown(KeyCode.R) || (OVRInput.Get(OVRInput.Button.Three) && OVRInput.Get(OVRInput.Button.Four)))
             {
                 // spawnPointが設定されていれば、その位置に移動
                 if (spawnPoint != null)
@@ -80,7 +75,6 @@ public class MouseMove : MonoBehaviour
                     return; // このフレームでは他の移動処理を行わない
                 }
             }
-            // --- 追加ここまで ---
 
             // 右手と左手の速度を取得
             Vector3 velocityR = OVRInput.GetLocalControllerVelocity(OVRInput.Controller.RTouch);
@@ -93,12 +87,11 @@ public class MouseMove : MonoBehaviour
             // カメラの位置をねずみの位置に合わせる
             Vector3 cameraPosition = transform.position;
             cameraPosition.y += 0.2f; // y軸を+0.2
-            // --- 修正 ---
+            
             if (mouseOVRCameraRig != null) // Nullチェックを追加してエラーを回避
             {
                 mouseOVRCameraRig.transform.position = cameraPosition;
             }
-            // --- 修正ここまで ---
 
             // カメラの向きをねずみの向きに合わせる
             Quaternion targetRotation = Quaternion.Euler(0, mouseCamera.transform.eulerAngles.y, 0);

--- a/Pandator/Assets/Mouse/Scripts/MouseMove.cs
+++ b/Pandator/Assets/Mouse/Scripts/MouseMove.cs
@@ -26,6 +26,10 @@ public class MouseMove : MonoBehaviour
     private float xAngle = 0f;
     private float yAngle = 0f;
     
+    // --- 追加 ---
+    private Transform spawnPoint; // スポーン地点のTransform
+    // --- 追加ここまで ---
+    
 
     private void Start()
     {
@@ -33,6 +37,20 @@ public class MouseMove : MonoBehaviour
         moveSpeed = normalSpeed; // 初期値を通常速度に設定
         InitializeManager = GameObject.FindWithTag("InitializeManager").GetComponent<InitializeManager>();
         floarValue = InitializeManager.GetLocalAnchorPosition().y;
+
+        // --- 追加 ---
+        // "playerSpawn"タグを持つゲームオブジェクトを検索して登録
+        GameObject spawnObject = GameObject.FindWithTag("playerSpawn");
+        if (spawnObject != null)
+        {
+            spawnPoint = spawnObject.transform;
+        }
+        else
+        {
+            // 見つからなかった場合にエラーメッセージを表示
+            Debug.LogError("Error: 'playerSpawn' tag not found in the scene.");
+        }
+        // --- 追加ここまで ---
     }
 
     private void Update()
@@ -45,18 +63,42 @@ public class MouseMove : MonoBehaviour
         // IsMineで自分のキャラクターかどうかを判定
         if (GetComponent<PhotonView>().IsMine)
         {
+            // --- 追加 ---
+            // キーボードの'R'キーか、Meta Questの右コントローラーの'A'ボタンが押された瞬間をチェック
+            if (Input.GetKeyDown(KeyCode.R) || OVRInput.GetDown(OVRInput.Button.One, OVRInput.Controller.RTouch))
+            {
+                // spawnPointが設定されていれば、その位置に移動
+                if (spawnPoint != null)
+                {
+                    transform.position = spawnPoint.position;
+                    // テレポート後の慣性をなくすため、Rigidbodyの速度をリセット
+                    if (rb != null)
+                    {
+                        rb.linearVelocity = Vector3.zero;
+                        rb.angularVelocity = Vector3.zero;
+                    }
+                    return; // このフレームでは他の移動処理を行わない
+                }
+            }
+            // --- 追加ここまで ---
+
             // 右手と左手の速度を取得
             Vector3 velocityR = OVRInput.GetLocalControllerVelocity(OVRInput.Controller.RTouch);
             Vector3 velocityL = OVRInput.GetLocalControllerVelocity(OVRInput.Controller.LTouch);
 
-            // XZ平面上の速度の合計を計算
+            // Y軸方向の速度の絶対値を取得
             float speedR = Mathf.Abs(velocityR.y);
             float speedL = Mathf.Abs(velocityL.y);
 
             // カメラの位置をねずみの位置に合わせる
             Vector3 cameraPosition = transform.position;
             cameraPosition.y += 0.2f; // y軸を+0.2
-            mouseOVRCameraRig.transform.position = cameraPosition;
+            // --- 修正 ---
+            if (mouseOVRCameraRig != null) // Nullチェックを追加してエラーを回避
+            {
+                mouseOVRCameraRig.transform.position = cameraPosition;
+            }
+            // --- 修正ここまで ---
 
             // カメラの向きをねずみの向きに合わせる
             Quaternion targetRotation = Quaternion.Euler(0, mouseCamera.transform.eulerAngles.y, 0);
@@ -83,11 +125,12 @@ public class MouseMove : MonoBehaviour
             // 移動処理
             if (isCollisionWall)
             {
+                // 壁に接触している間は登る
                 transform.position += transform.up * Time.deltaTime * climbSpeed;
             }
             else
             {
-                // キーボード操作
+                // キーボード操作の場合、移動方向と速度を上書き
                 if (isKeybord)
                 {
                     float moveX = Input.GetAxis("Horizontal");
@@ -96,6 +139,7 @@ public class MouseMove : MonoBehaviour
                     totalSpeed = 2f;
                     forwardDirection.Normalize();
                 }
+                // 通常の移動
                 transform.Translate(forwardDirection * totalSpeed * Time.deltaTime, Space.World);
             }
         }
@@ -106,6 +150,7 @@ public class MouseMove : MonoBehaviour
             transform.position = new Vector3(transform.position.x, floarValue + 0.1f, transform.position.z);
         }
         
+        // マウスでのカメラ操作
         if (isKeybord)
         {
             float mouseX = Input.GetAxis("Mouse X");
@@ -113,7 +158,6 @@ public class MouseMove : MonoBehaviour
             xAngle -= mouseY;
             xAngle = Mathf.Clamp(xAngle, -90f, 90f);
             yAngle += mouseX;
-            // yAngle = Mathf.Clamp(yAngle, -90f, 90f);
             Camera.main.transform.localRotation = Quaternion.Euler(xAngle, yAngle, 0);
         }
     }
@@ -135,7 +179,7 @@ public class MouseMove : MonoBehaviour
 
     private void OnCollisionEnter(Collision collision)
     {
-        if (collision.gameObject.tag == "Wall")
+        if (collision.gameObject.CompareTag("Wall"))
         {
             isCollisionWall = true;
             rb.useGravity = false;
@@ -144,7 +188,7 @@ public class MouseMove : MonoBehaviour
 
     private void OnCollisionExit(Collision collision)
     {
-        if (collision.gameObject.tag == "Wall")
+        if (collision.gameObject.CompareTag("Wall"))
         {
             rb.useGravity = true;
             isCollisionWall = false;

--- a/Pandator/Assets/Rabbit/Scripts/RabbitMove.cs
+++ b/Pandator/Assets/Rabbit/Scripts/RabbitMove.cs
@@ -22,6 +22,11 @@ public class RabbitMove : MonoBehaviour
     private bool isKeybord = false;
     private float xAngle = 0f;
     private float yAngle = 0f;
+
+    // --- 追加 ---
+    [Header("スポーン地点")]
+    private Transform spawnPoint; // スポーン地点のTransform
+    // --- 追加ここまで ---
     
     void Start()
     {
@@ -30,6 +35,17 @@ public class RabbitMove : MonoBehaviour
         InitializeManager = GameObject.FindWithTag("InitializeManager").GetComponent<InitializeManager>();
         floarValue = InitializeManager.GetLocalAnchorPosition().y;
         
+        // playerSpawnタグを持つゲームオブジェクトを検索して登録
+        GameObject spawnObject = GameObject.FindWithTag("playerSpawn");
+        if (spawnObject != null)
+        {
+            spawnPoint = spawnObject.transform;
+        }
+        else
+        {
+            // 見つからなかった場合にエラーメッセージを表示
+            Debug.LogError("Error: 'playerSpawn' tag not found in the scene.");
+        }
     }
 
     void Update()
@@ -43,6 +59,25 @@ public class RabbitMove : MonoBehaviour
         //IsMineで自分のキャラクターかどうかを判定
         if (GetComponent<PhotonView>().IsMine)
         {
+            // --- 追加 ---
+            // キーボードの'R'キーか、Meta Questの右コントローラーの'A'ボタンが押された瞬間をチェック
+            if (Input.GetKeyDown(KeyCode.R) || OVRInput.GetDown(OVRInput.Button.One, OVRInput.Controller.RTouch))
+            {
+                // spawnPointが設定されていれば、その位置に移動
+                if (spawnPoint != null)
+                {
+                    transform.position = spawnPoint.position;
+                    // テレポート後の慣性をなくすため、Rigidbodyの速度をリセット
+                    if (rb != null)
+                    {
+                        rb.linearVelocity = Vector3.zero;
+                        rb.angularVelocity = Vector3.zero;
+                    }
+                    return; // このフレームでは他の移動処理を行わない
+                }
+            }
+            // --- 追加ここまで ---
+
             // 左スティックの入力を0にする
             Vector2 leftStick = OVRInput.Get(OVRInput.Axis2D.PrimaryThumbstick);
             leftStick = Vector2.zero; // 強引に0にする
@@ -51,17 +86,22 @@ public class RabbitMove : MonoBehaviour
             Vector3 velocityR = OVRInput.GetLocalControllerVelocity(OVRInput.Controller.RTouch);
             Vector3 velocityL = OVRInput.GetLocalControllerVelocity(OVRInput.Controller.LTouch);
 
-            // 右手のAボタンが押されたかチェック
+            // 右手のAボタンが押され続けているかチェック (これは移動停止用なのでGetのまま)
             bool isAButtonPressed = OVRInput.Get(OVRInput.Button.One, OVRInput.Controller.RTouch);
 
-            // XZ平面上の速度の合計を計算
+            // Y軸方向の速度の絶対値を取得
             float speedR = Mathf.Abs(velocityR.y);
             float speedL = Mathf.Abs(velocityL.y);
 
             // カメラの位置をうさぎの位置に合わせる
             Vector3 cameraPosition = transform.position;
             cameraPosition.y += 0.2f; // y軸を+0.2
-            rabbitOVRCameraRig.transform.position = cameraPosition;
+            // --- 修正 ---
+            if (rabbitOVRCameraRig != null) // Nullチェックを追加してエラーを回避
+            {
+                rabbitOVRCameraRig.transform.position = cameraPosition;
+            }
+            // --- 修正ここまで ---
 
             // カメラの向きをうさぎの向きに合わせる
             Quaternion targetRotation = Quaternion.Euler(0, rabbitCamera.transform.eulerAngles.y, 0);
@@ -70,7 +110,7 @@ public class RabbitMove : MonoBehaviour
             // 速度が閾値以下の場合は移動しない
             if (speedR < speedThreshold && speedL < speedThreshold && !isKeybord)
             {
-                // 速度が閾値以下の場合は移動しない
+                // 速度が閾値以下で、さらにAボタンが押されている場合も移動しない
                 if (isAButtonPressed)
                 {
                     transform.Translate(Vector3.zero);
@@ -85,21 +125,18 @@ public class RabbitMove : MonoBehaviour
             Vector3 forwardDirection = headTransform.forward;
             forwardDirection.y = 0; // 水平移動のみ考慮
             forwardDirection.Normalize();
-
-            // 移動処理
+    
+            // 元のコードで重複していた条件分岐を修正
             if (!isAButtonPressed && !isKeybord)
             {
-                transform.Translate(forwardDirection * totalSpeed * Time.deltaTime, Space.World);
-            }else if(!isAButtonPressed && !isKeybord)
-            {
-                transform.Translate( JUMP_MOVE_SPEED * forwardDirection * totalSpeed * Time.deltaTime, Space.World);
-            }else if (isKeybord)
+                transform.Translate(forwardDirection * JUMP_MOVE_SPEED * totalSpeed * Time.deltaTime, Space.World);
+            }
+            else if (isKeybord)
             {
                 float moveX = Input.GetAxis("Horizontal");
                 float moveZ = Input.GetAxis("Vertical");
             
-
-                forwardDirection = Camera.main.transform.right* moveX + Camera.main.transform.forward * moveZ;
+                forwardDirection = Camera.main.transform.right * moveX + Camera.main.transform.forward * moveZ;
                 totalSpeed = 2f;
                 transform.Translate(forwardDirection.normalized * totalSpeed * Time.deltaTime, Space.World);
             }
@@ -112,7 +149,6 @@ public class RabbitMove : MonoBehaviour
                 xAngle -= mouseY;
                 xAngle = Mathf.Clamp(xAngle, -90f, 90f);
                 yAngle += mouseX;
-                // yAngle = Mathf.Clamp(yAngle, -90f, 90f);
                 Camera.main.transform.localRotation = Quaternion.Euler(xAngle, yAngle, 0);
             }
             

--- a/Pandator/Assets/Rabbit/Scripts/RabbitMove.cs
+++ b/Pandator/Assets/Rabbit/Scripts/RabbitMove.cs
@@ -22,11 +22,9 @@ public class RabbitMove : MonoBehaviour
     private bool isKeybord = false;
     private float xAngle = 0f;
     private float yAngle = 0f;
-
-    // --- 追加 ---
+    
     [Header("スポーン地点")]
     private Transform spawnPoint; // スポーン地点のTransform
-    // --- 追加ここまで ---
     
     void Start()
     {
@@ -59,9 +57,8 @@ public class RabbitMove : MonoBehaviour
         //IsMineで自分のキャラクターかどうかを判定
         if (GetComponent<PhotonView>().IsMine)
         {
-            // --- 追加 ---
-            // キーボードの'R'キーか、Meta Questの右コントローラーの'A'ボタンが押された瞬間をチェック
-            if (Input.GetKeyDown(KeyCode.R) || OVRInput.GetDown(OVRInput.Button.One, OVRInput.Controller.RTouch))
+            // キーボードの'R'キーか、Meta Questの左コントローラーの'X,Y'ボタンが押された瞬間をチェック
+            if (Input.GetKeyDown(KeyCode.R) || (OVRInput.Get(OVRInput.Button.Three) && OVRInput.Get(OVRInput.Button.Four)))
             {
                 // spawnPointが設定されていれば、その位置に移動
                 if (spawnPoint != null)
@@ -76,7 +73,6 @@ public class RabbitMove : MonoBehaviour
                     return; // このフレームでは他の移動処理を行わない
                 }
             }
-            // --- 追加ここまで ---
 
             // 左スティックの入力を0にする
             Vector2 leftStick = OVRInput.Get(OVRInput.Axis2D.PrimaryThumbstick);
@@ -96,12 +92,11 @@ public class RabbitMove : MonoBehaviour
             // カメラの位置をうさぎの位置に合わせる
             Vector3 cameraPosition = transform.position;
             cameraPosition.y += 0.2f; // y軸を+0.2
-            // --- 修正 ---
+            
             if (rabbitOVRCameraRig != null) // Nullチェックを追加してエラーを回避
             {
                 rabbitOVRCameraRig.transform.position = cameraPosition;
             }
-            // --- 修正ここまで ---
 
             // カメラの向きをうさぎの向きに合わせる
             Quaternion targetRotation = Quaternion.Euler(0, rabbitCamera.transform.eulerAngles.y, 0);


### PR DESCRIPTION
## 壁抜けや、床抜けした時用の位置リセットボタンの追加
#

## 概要
前回までの体験の中で、小動物の予期せぬ壁抜けや床抜け等が発生したので、
応急処置として小動物の生成位置に強制的に移動させるボタンを追加した

## 実装結果・プレビュー
実機での確認及びGod視点で正しく位置が変わっていることも確認した